### PR TITLE
 delete autoform version dependency as now we have autoform 5.0.2

### DIFF
--- a/package.js
+++ b/package.js
@@ -12,7 +12,7 @@ Package.onUse(function(api) {
 
   api.use([
     'templating',
-    'aldeed:autoform@4.2.2'
+    'aldeed:autoform'
   ], both);
   api.use('summernote:standalone@0.6.0_1', 'client');
 

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'mpowaga:autoform-summernote',
   summary: 'Summernote editor for aldeed:autoform',
-  version: '0.3.1',
+  version: '0.3.2',
   git: 'https://github.com/mpowaga/meteor-autoform-summernote'
 });
 


### PR DESCRIPTION
It is impossible to update autoform to 5.0.2 wile having package requestion lower version.
And in new version of autoform a lot of changes are done.