### PR TITLE
Patch autosave issue caused by summernote issue / Cleanup hacky code

### DIFF
--- a/lib/client/templates.js
+++ b/lib/client/templates.js
@@ -1,47 +1,48 @@
-Template.afSummernote.created = function () {
-  this.value = new ReactiveVar(this.data.value);
-};
-
-Template.afSummernote.rendered = function() {
+Template.afSummernote.onRendered(function() {
   var self = this;
   var options = this.data.atts.settings || {};
   var $editor = $(this.firstNode);
-  
-  var onblur = options.onblur;
-  options.onblur = function(e) {
-    $editor.change();
-    if (typeof onblur === 'function') {
-      onblur.apply(this, arguments);
-    }
-  };
+  this.$editor = $editor
+  this.onblur = options.onblur;
 
   $editor.summernote(options);
-
+ 
+  var value = null;
   this.autorun(function () {
-    $editor.summernote('code', self.value.get());
+    var dataContext = Template.currentData();
+    if (value!=dataContext.value) {
+      $editor.summernote('code', dataContext.value);
+      value = dataContext.value;
+    }
   });
 
   $editor.closest('form').on('reset', function() {
     $editor.summernote('code', '');
   });
-};
+});
+
+
+Template.afSummernote.events({
+  'summernote.blur': function(event, template) {
+    template.$(event.target)[0].value = template.$(event.target).summernote('code');
+    template.$(event.target).change();
+    var onblur = template.onblur;
+    if (typeof onblur === 'function') {
+      onblur.apply(this, arguments);
+    }
+  }
+});
+
+Template.afSummernote.onDestroyed(function() {
+  if (this.$editor){ 
+    this.$editor.summernote('destroy');
+  }
+});
 
 Template.afSummernote.helpers({
   atts: function () {
     var self = this;
 
-    /**
-     * This is bit hacky but created and rendered callback sometimes
-     * (or always?) get empty value. This helper gets called multiple
-     * times so we intercept and save the value once it is not empty.
-     */
-    Tracker.nonreactive(function () {
-      var t = Template.instance();
-      if (t.value.get() !== self.value) {
-        t.value.set(self.value);
-      }
-    });
-    
     return _.omit(this.atts, 'settings');
   }
 });

--- a/lib/client/templates.js
+++ b/lib/client/templates.js
@@ -24,8 +24,12 @@ Template.afSummernote.onRendered(function() {
 
 Template.afSummernote.events({
   'summernote.blur': function(event, template) {
+    // Unfortunatly there seems to be an issue where value is not updated in the
+    // summernote code in some cases. We are just garenteeing that this is updated before 
+    // triggering the autform change detection
     template.$(event.target)[0].value = template.$(event.target).summernote('code');
     template.$(event.target).change();
+
     var onblur = template.onblur;
     if (typeof onblur === 'function') {
       onblur.apply(this, arguments);


### PR DESCRIPTION
This patches an issue with autosave. When i would highlight text and then change font size autosave would stop working. The value was not being updated from summernote. Now I force the value to be set before triggering a change that autform will detect.

Use onRendered instead of rendered = function() {} 
Remove hacky code and detect data context change the right way.
